### PR TITLE
Feature/validate and add to package

### DIFF
--- a/.github/workflows/deployPackage.yml
+++ b/.github/workflows/deployPackage.yml
@@ -1,0 +1,28 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Deploy package
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Publish package
+        run: mvn --batch-mode deploy -DgithubRepository=${{github.repository}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,29 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Verify the project
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Verify Project
+        run: mvn -B verify --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -689,4 +689,12 @@
 
     </profiles>
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/${githubRepository}</url>
+        </repository>
+    </distributionManagement>
+
 </project>


### PR DESCRIPTION
These two actions have the following tasks:

1. validate the pom.xml with every push

2. a packege is created for each relese and uploaded to github. This means that it can be referenced again in another project for the build. You can see how this could work here in my fork https://github.com/P8hJ/eblocker-top/tree/feature/validateAndAddToPackage

This could simplify the instructions for checking out the sources. You could build any project without having to build other projects first. If we want to do it this way, then it's time to rebuild the other projects according to this concept.

It's not clear to me whether this is the way to do it, it's just my suggestion.