### PR TITLE
JUnit5 compatibility is established

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eblocker</groupId>
     <artifactId>eblocker-top</artifactId>
-    <version>2.4.13</version>
+    <version>2.4.14</version>
     <packaging>pom</packaging>
     <name>eBlocker - Common Project Definitions</name>
 
@@ -58,6 +58,8 @@
         <version.httpclient>4.5.13</version.httpclient>
 
         <version.junit>4.13.1</version.junit>
+        <version.junit5>5.10.1</version.junit5>
+        <version.junit.vintage>5.10.1</version.junit.vintage>
         <version.mockito>3.3.3</version.mockito>
         <version.embedded-redis>0.6</version.embedded-redis>
         <version.subethasmtp>3.1.7</version.subethasmtp>
@@ -412,11 +414,16 @@
             </dependency>
 
             <!-- Test only -->
-
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${version.junit}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${version.junit5}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -469,7 +476,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -616,6 +623,17 @@
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>2.9</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.vintage</groupId>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <version>${version.junit.vintage}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 
@@ -663,8 +681,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <!-- Minimal supported version is 2.4 -->
-                        <version>2.13</version>
                         <configuration>
                             <properties>
                                 <property>
@@ -693,6 +709,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
+            <!--suppress UnresolvedMavenProperty -->
             <url>https://maven.pkg.github.com/${githubRepository}</url>
         </repository>
     </distributionManagement>


### PR DESCRIPTION
On this branch you can see how the other projects can use this JUnit 5 lib: https://github.com/P8hJ/eblocker-crypto/tree/feature/junit5

The build is not running now because this PR is not yet merged.