### PR TITLE
postgresql removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
         <version.embedded-redis>0.6</version.embedded-redis>
         <version.subethasmtp>3.1.7</version.subethasmtp>
         <version.hikaricp>2.4.5</version.hikaricp>
-        <version.postgresql>42.3.7</version.postgresql>
         <version.liquibase-hibernate4>3.5</version.liquibase-hibernate4>
         <version.liquibase-slf4j>1.2.1</version.liquibase-slf4j>
         <version.liquibase>4.8.0</version.liquibase>
@@ -357,12 +356,6 @@
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-servlet</artifactId>
                 <version>${version.dropwizard.metrics}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>${version.postgresql}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
I discovered the dependabot on github. I activated it once on the eblocker-top in my fork. It created a few PRs for me, which I am now checking one by one. The first is that it notes the version of PostgreSQL. I made the change locally and then wanted to check whether the new version was being used in the other projects. However, I did not find a reference to the PostgreSQL lib in any project. For this reason, I suggest deleting it.

Everything could be compiled and all tests worked. I checked this with this script. Have I overlooked something?

#!/bin/bash
set -e
cd ../eblocker-top || exit
mvn clean install

cd ../eblocker-crypto || exit
mvn clean install

cd ../eblocker-registration-api || exit
mvn clean install

cd ../netty-icap || exit
mvn clean install

cd ../eblocker-lists || exit
mvn clean install

cd ../eblocker || exit
mvn clean test